### PR TITLE
feat(nav): add mobile-only BottomNavBar [MFS-TSK-0007]

### DIFF
--- a/src/components/BottomNavBar.astro
+++ b/src/components/BottomNavBar.astro
@@ -1,0 +1,143 @@
+---
+import { primaryNav } from '~/data/navigation';
+
+interface Props {
+  active?: 'home' | 'leadership' | 'tech' | 'contact';
+  language: 'es' | 'en';
+}
+
+const { active = 'home', language = 'es' } = Astro.props;
+---
+
+<nav class="bottom-nav u-glass" aria-label="Primary mobile">
+  <ul>
+    {primaryNav.map((item) => (
+      <li>
+        <a
+          href={item.href(language)}
+          class="bottom-nav__link"
+          aria-current={active === item.id ? 'page' : undefined}
+        >
+          <span class="bottom-nav__icon" aria-hidden="true">
+            {item.id === 'home' && (
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M3 10.5 12 3l9 7.5V20a1 1 0 0 1-1 1h-5v-7h-6v7H4a1 1 0 0 1-1-1Z" />
+              </svg>
+            )}
+            {item.id === 'leadership' && (
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M12 21s-7-4.5-7-10a4 4 0 0 1 7-2.65A4 4 0 0 1 19 11c0 5.5-7 10-7 10Z" />
+              </svg>
+            )}
+            {item.id === 'tech' && (
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M4 6h16v12H4z" />
+                <path d="m8 10 2 2-2 2" />
+                <path d="M12 14h4" />
+              </svg>
+            )}
+            {item.id === 'contact' && (
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="3" y="5" width="18" height="14" rx="1.5" />
+                <path d="m3.5 6.5 8.5 6 8.5-6" />
+              </svg>
+            )}
+          </span>
+          <span class="bottom-nav__label">
+            {language === 'es' ? item.es : item.en}
+          </span>
+        </a>
+      </li>
+    ))}
+  </ul>
+</nav>
+
+<style>
+  .bottom-nav {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 50;
+    padding-bottom: env(safe-area-inset-bottom, 0);
+    border-top: 1px solid color-mix(in srgb, var(--outline-variant) 15%, transparent);
+  }
+
+  .bottom-nav ul {
+    list-style: none;
+    margin: 0;
+    padding: 0.5rem clamp(0.75rem, 3vw, 1.5rem);
+    display: flex;
+    justify-content: space-around;
+    align-items: stretch;
+  }
+
+  .bottom-nav li {
+    flex: 1 1 0;
+    display: flex;
+    justify-content: center;
+  }
+
+  .bottom-nav__link {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.5rem 0.25rem;
+    color: var(--on-surface-variant);
+    text-decoration: none;
+    transition: color 200ms var(--ease-3);
+  }
+
+  /* Symmetric to the TopAppBar: active line sits at the INNER edge */
+  .bottom-nav__link::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 50%;
+    width: 0;
+    height: 2px;
+    background-color: var(--primary-fixed-dim);
+    transform: translateX(-50%);
+    transition: width 260ms var(--ease-3);
+  }
+
+  .bottom-nav__link:hover { color: var(--on-surface); }
+
+  .bottom-nav__link[aria-current='page'] {
+    color: var(--primary-fixed-dim);
+  }
+  .bottom-nav__link[aria-current='page']::before {
+    width: 1.25rem;
+  }
+
+  .bottom-nav__icon {
+    display: inline-flex;
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+  .bottom-nav__icon svg {
+    width: 100%;
+    height: 100%;
+  }
+
+  .bottom-nav__label {
+    font-family: 'Inter', sans-serif;
+    font-size: 0.625rem;
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  @media (min-width: 768px) {
+    .bottom-nav { display: none; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .bottom-nav__link,
+    .bottom-nav__link::before {
+      transition: none;
+    }
+  }
+</style>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,6 @@
 ---
 import BaseHead from '~/components/BaseHead.astro';
+import BottomNavBar from '~/components/BottomNavBar.astro';
 import { Site } from '~/data/config';
 import '~/styles/layout.css';
 import '~/styles/fonts.css';
@@ -10,9 +11,10 @@ interface Props {
   includeSchema?: boolean;
   description?: string;
   image?: string;
+  active?: 'home' | 'leadership' | 'tech' | 'contact';
 }
 
-const { title, includeSchema = false, description = Site.description, image = '/manufosela.png' } = Astro.props;
+const { title, includeSchema = false, description = Site.description, image = '/manufosela.png', active = 'home' } = Astro.props;
 
 const isProduction = import.meta.env.PROD;
 const lang = Astro.url.pathname.startsWith('/en') ? 'en' : 'es';
@@ -41,6 +43,7 @@ const lang = Astro.url.pathname.startsWith('/en') ? 'en' : 'es';
   </head>
   <body>
     <slot />
+    <BottomNavBar active={active} language={lang} />
   </body>
 </html>
 
@@ -53,5 +56,12 @@ const lang = Astro.url.pathname.startsWith('/en') ? 'en' : 'es';
 
   main {
     flex: 1;
+  }
+
+  /* Reserve space so BottomNavBar does not cover the last block on mobile */
+  @media (max-width: 767px) {
+    body {
+      padding-bottom: calc(4.5rem + env(safe-area-inset-bottom, 0));
+    }
   }
 </style>


### PR DESCRIPTION
## Summary
- New \`src/components/BottomNavBar.astro\`: sticky bottom navigation visible on \`<768 px\`
- 4 items (home, leadership, tech, contact) sourced from \`src/data/navigation.js\`
- Inline SVG icons (1.75 stroke weight) — no external icon font
- Glass background via \`.u-glass\`, border-top \`outline-variant/15%\`, safe-area-inset aware
- Active indicator: mint 1.25rem line at the TOP of the active item (symmetric echo of TopAppBar's bottom line)
- Layout.astro gains optional \`active\` prop (default \`'home'\`) and reserves 4.5rem body bottom padding on mobile

## Test plan
- [x] \`npm run build\` passes (18 pages)
- [ ] \`<768 px\`: bar visible at bottom, icon + label, safe-area respected
- [ ] \`≥768 px\`: bar hidden
- [ ] Active item shows mint color + top indicator line
- [ ] Content not clipped behind bar on mobile

Card: MFS-TSK-0007