### PR TITLE
refactor(layout): promote Header and BottomNavBar into Layout shell [MFS-TSK-0008]

### DIFF
--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -1,6 +1,5 @@
 ---
 import { indexDesc } from '~/data/index';
-import Header from '~/components/Header.astro';
 import Bio from '~/components/Bio.astro';
 import SocialNets from '~/components/SocialNets.astro';
 import Footer from '~/components/Footer.astro';
@@ -9,10 +8,9 @@ import BookPromotion from '~/components/BookPromotion.astro';
 
 interface Props {
   language: 'es' | 'en';
-  title: string;
 }
 
-const { language, title } = Astro.props;
+const { language } = Astro.props;
 const indexDescription = indexDesc[language];
 ---
 
@@ -20,7 +18,6 @@ const indexDescription = indexDesc[language];
   <ResponsiveImage imagePath="/images/manufosela/manufosela" description={indexDescription} />
 
   <section class="maincontent">
-    <Header active="home" language={language} />
     <div class="pagecontent">
       <Bio language={language} />
       <BookPromotion language={language} />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,6 @@
 ---
 import BaseHead from '~/components/BaseHead.astro';
+import Header from '~/components/Header.astro';
 import BottomNavBar from '~/components/BottomNavBar.astro';
 import { Site } from '~/data/config';
 import '~/styles/layout.css';
@@ -42,6 +43,7 @@ const lang = Astro.url.pathname.startsWith('/en') ? 'en' : 'es';
     </style>
   </head>
   <body>
+    <Header active={active} language={lang} />
     <slot />
     <BottomNavBar active={active} language={lang} />
   </body>

--- a/src/pages/en/about.astro
+++ b/src/pages/en/about.astro
@@ -1,6 +1,5 @@
 ---
 import Layout from '~/layouts/Layout.astro';
-import Header from '~/components/Header.astro';
 import AboutContent from '~/components/About.astro';
 import SocialNets from '~/components/SocialNets.astro';
 import Footer from '~/components/Footer.astro';
@@ -13,12 +12,11 @@ const language = 'en';
 const aboutDescription = aboutDesc[language];
 ---
 
-<Layout {title}>
+<Layout {title} active="home">
   <main>
     <ResponsiveImage imagePath="/images/about" description={aboutDescription} />
 
     <div class="maincontent w-col w-col-6 w-col-stack">
-      <Header active="home" language={language} />
       <AboutContent language={language} />
       <SocialNets language={language} />
       <Footer language={language} />

--- a/src/pages/en/articles.astro
+++ b/src/pages/en/articles.astro
@@ -1,6 +1,5 @@
 ---
 import Layout from '~/layouts/Layout.astro';
-import Header from '~/components/Header.astro';
 import ArticlesContent from '~/components/Articles.astro';
 import SocialNets from '~/components/SocialNets.astro';
 import Footer from '~/components/Footer.astro';
@@ -13,12 +12,11 @@ const language = 'en';
 const articlesDescription = articlesDesc[language];
 ---
 
-<Layout {title}>
+<Layout {title} active="tech">
   <main>
     <ResponsiveImage imagePath="/images/articles" description={articlesDescription} />
 
     <div class="maincontent w-col w-col-6 w-col-stack">
-      <Header active="tech" language={language} />
       <ArticlesContent language={language} />
       <SocialNets language={language} />
       <Footer language={language} />

--- a/src/pages/en/contact.astro
+++ b/src/pages/en/contact.astro
@@ -1,14 +1,11 @@
 ---
 import Layout from '~/layouts/Layout.astro';
-import Header from '~/components/Header.astro';
 import { Site } from '~/data/config';
 
 const title = `${Site.title} — Contact`;
-const language = 'en';
 ---
 
-<Layout {title}>
-  <Header active="contact" language={language} />
+<Layout {title} active="contact">
   <main class="placeholder">
     <p class="u-label u-label--accent">Coming soon</p>
     <h1>Contact</h1>

--- a/src/pages/en/contributions.astro
+++ b/src/pages/en/contributions.astro
@@ -1,6 +1,5 @@
 ---
 import Layout from '~/layouts/Layout.astro';
-import Header from '~/components/Header.astro';
 import ContributionsContent from '~/components/Contributions.astro';
 import SocialNets from '~/components/SocialNets.astro';
 import Footer from '~/components/Footer.astro';
@@ -13,12 +12,11 @@ const language = 'en';
 const contributionsDescription = contributionsDesc[language];
 ---
 
-<Layout {title}>
+<Layout {title} active="tech">
   <main>
     <ResponsiveImage imagePath="/images/contributions" description={contributionsDescription} />
 
     <div class="maincontent w-col w-col-6 w-col-stack">
-      <Header active="tech" language={language} />
       <ContributionsContent language={language} />
       <SocialNets language={language} />
       <Footer language={language} />

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -7,6 +7,6 @@ const title = Site.title;
 const language = 'en';
 ---
 
-<Layout {title} includeSchema={true}>
-  <Card language={language} title={title} />
+<Layout {title} includeSchema={true} active="home">
+  <Card language={language} />
 </Layout>

--- a/src/pages/en/leadership.astro
+++ b/src/pages/en/leadership.astro
@@ -1,14 +1,11 @@
 ---
 import Layout from '~/layouts/Layout.astro';
-import Header from '~/components/Header.astro';
 import { Site } from '~/data/config';
 
 const title = `${Site.title} — Leadership`;
-const language = 'en';
 ---
 
-<Layout {title}>
-  <Header active="leadership" language={language} />
+<Layout {title} active="leadership">
   <main class="placeholder">
     <p class="u-label u-label--accent">Coming soon</p>
     <h1>Affective Leadership</h1>

--- a/src/pages/en/media.astro
+++ b/src/pages/en/media.astro
@@ -1,6 +1,5 @@
 ---
 import Layout from '~/layouts/Layout.astro';
-import Header from '~/components/Header.astro';
 import MediaContent from '~/components/Media.astro';
 import SocialNets from '~/components/SocialNets.astro';
 import Footer from '~/components/Footer.astro';
@@ -13,12 +12,11 @@ const language = 'en';
 const mediaDescription = mediaDesc[language];
 ---
 
-<Layout {title}>
+<Layout {title} active="tech">
   <main>
     <ResponsiveImage imagePath="/images/media" description={mediaDescription} />
 
     <div class="maincontent w-col w-col-6 w-col-stack">
-      <Header active="tech" language={language} />
       <MediaContent language={language} />
       <SocialNets language={language} />
       <Footer language={language} />

--- a/src/pages/en/tech.astro
+++ b/src/pages/en/tech.astro
@@ -1,14 +1,11 @@
 ---
 import Layout from '~/layouts/Layout.astro';
-import Header from '~/components/Header.astro';
 import { Site } from '~/data/config';
 
 const title = `${Site.title} — Tech Hub`;
-const language = 'en';
 ---
 
-<Layout {title}>
-  <Header active="tech" language={language} />
+<Layout {title} active="tech">
   <main class="placeholder">
     <p class="u-label u-label--accent">Coming soon</p>
     <h1>Tech Hub</h1>

--- a/src/pages/es/about.astro
+++ b/src/pages/es/about.astro
@@ -1,6 +1,5 @@
 ---
 import Layout from '~/layouts/Layout.astro';
-import Header from '~/components/Header.astro';
 import AboutContent from '~/components/About.astro';
 import SocialNets from '~/components/SocialNets.astro';
 import Footer from '~/components/Footer.astro';
@@ -13,12 +12,11 @@ const language = 'es';
 const aboutDescription = aboutDesc[language];
 ---
 
-<Layout {title}>
+<Layout {title} active="home">
   <main>
     <ResponsiveImage imagePath="/images/about" description={aboutDescription} />
 
     <div class="maincontent w-col w-col-6 w-col-stack">
-      <Header active="home" language={language} />
       <AboutContent language={language} />
       <SocialNets language={language} />
       <Footer language={language} />

--- a/src/pages/es/articles.astro
+++ b/src/pages/es/articles.astro
@@ -1,6 +1,5 @@
 ---
 import Layout from '~/layouts/Layout.astro';
-import Header from '~/components/Header.astro';
 import ArticlesContent from '~/components/Articles.astro';
 import SocialNets from '~/components/SocialNets.astro';
 import Footer from '~/components/Footer.astro';
@@ -13,12 +12,11 @@ const language = 'es';
 const articlesDescription = articlesDesc[language];
 ---
 
-<Layout {title}>
+<Layout {title} active="tech">
   <main>
     <ResponsiveImage imagePath="/images/articles" description={articlesDescription} />
 
     <div class="maincontent w-col w-col-6 w-col-stack">
-      <Header active="tech" language={language} />
       <ArticlesContent language={language} />
       <SocialNets language={language} />
       <Footer language={language} />

--- a/src/pages/es/contact.astro
+++ b/src/pages/es/contact.astro
@@ -1,14 +1,11 @@
 ---
 import Layout from '~/layouts/Layout.astro';
-import Header from '~/components/Header.astro';
 import { Site } from '~/data/config';
 
 const title = `${Site.title} — Contacto`;
-const language = 'es';
 ---
 
-<Layout {title}>
-  <Header active="contact" language={language} />
+<Layout {title} active="contact">
   <main class="placeholder">
     <p class="u-label u-label--accent">Próximamente</p>
     <h1>Contacto</h1>

--- a/src/pages/es/contributions.astro
+++ b/src/pages/es/contributions.astro
@@ -1,6 +1,5 @@
 ---
 import Layout from '~/layouts/Layout.astro';
-import Header from '~/components/Header.astro';
 import ContributionsContent from '~/components/Contributions.astro';
 import SocialNets from '~/components/SocialNets.astro';
 import Footer from '~/components/Footer.astro';
@@ -13,12 +12,11 @@ const language = 'es';
 const contributionsDescription = contributionsDesc[language];
 ---
 
-<Layout {title}>
+<Layout {title} active="tech">
   <main>
     <ResponsiveImage imagePath="/images/contributions" description={contributionsDescription} />
 
     <div class="maincontent w-col w-col-6 w-col-stack">
-      <Header active="tech" language={language} />
       <ContributionsContent language={language} />
       <SocialNets language={language} />
       <Footer language={language} />

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -7,6 +7,6 @@ const title = Site.title;
 const language = 'es';
 ---
 
-<Layout {title} includeSchema={true}>
-  <Card language={language} title={title} />
+<Layout {title} includeSchema={true} active="home">
+  <Card language={language} />
 </Layout>

--- a/src/pages/es/leadership.astro
+++ b/src/pages/es/leadership.astro
@@ -1,14 +1,11 @@
 ---
 import Layout from '~/layouts/Layout.astro';
-import Header from '~/components/Header.astro';
 import { Site } from '~/data/config';
 
 const title = `${Site.title} — Liderazgo`;
-const language = 'es';
 ---
 
-<Layout {title}>
-  <Header active="leadership" language={language} />
+<Layout {title} active="leadership">
   <main class="placeholder">
     <p class="u-label u-label--accent">Próximamente</p>
     <h1>Liderazgo Afectivo</h1>

--- a/src/pages/es/media.astro
+++ b/src/pages/es/media.astro
@@ -1,6 +1,5 @@
 ---
 import Layout from '~/layouts/Layout.astro';
-import Header from '~/components/Header.astro';
 import MediaContent from '~/components/Media.astro';
 import SocialNets from '~/components/SocialNets.astro';
 import Footer from '~/components/Footer.astro';
@@ -13,12 +12,11 @@ const language = 'es';
 const mediaDescription = mediaDesc[language];
 ---
 
-<Layout {title}>
+<Layout {title} active="tech">
   <main>
     <ResponsiveImage imagePath="/images/media" description={mediaDescription} />
 
     <div class="maincontent w-col w-col-6 w-col-stack">
-      <Header active="tech" language={language} />
       <MediaContent language={language} />
       <SocialNets language={language} />
       <Footer language={language} />

--- a/src/pages/es/tech.astro
+++ b/src/pages/es/tech.astro
@@ -1,14 +1,11 @@
 ---
 import Layout from '~/layouts/Layout.astro';
-import Header from '~/components/Header.astro';
 import { Site } from '~/data/config';
 
 const title = `${Site.title} — Tech Hub`;
-const language = 'es';
 ---
 
-<Layout {title}>
-  <Header active="tech" language={language} />
+<Layout {title} active="tech">
   <main class="placeholder">
     <p class="u-label u-label--accent">Próximamente</p>
     <h1>Tech Hub</h1>


### PR DESCRIPTION
## Summary
- Move Header from per-page imports up into \`Layout.astro\` — single shell for TopAppBar + BottomNavBar
- Pages declare the active nav via a new \`active\` prop on Layout (\`'home' | 'leadership' | 'tech' | 'contact'\`)
- Remove \`import Header\` + JSX usage from 15 call sites: \`Card.astro\`, the 8 legacy subpages (about/articles/media/contributions × es/en) and the 6 placeholder pages (leadership/tech/contact × es/en)
- Legacy subpages temporarily map \`about\` → \`active="home"\`, \`articles/media/contributions\` → \`active="tech"\` until EPIC-05/06 retire them

## Context
Closes the EPIC-02 Layout Shell: TopAppBar + BottomNavBar now render once from Layout, not per page. Future hero/bento refactors can focus on content without touching navigation.

## Test plan
- [x] \`npm run build\` passes (18 pages)
- [ ] Every page shows exactly one sticky TopAppBar at top and one mobile BottomNavBar at bottom (≤767 px)
- [ ] Active nav item matches the current page section

Card: MFS-TSK-0008