### PR TITLE
feat(home): add HeroHome with editorial portrait + gradient [MFS-TSK-0009]

### DIFF
--- a/src/components/HeroHome.astro
+++ b/src/components/HeroHome.astro
@@ -1,0 +1,207 @@
+---
+import { ManuFosela, indexDesc } from '~/data/index';
+
+interface Props {
+  language: 'es' | 'en';
+}
+
+const { language } = Astro.props;
+
+const person = ManuFosela[language];
+const altText = indexDesc[language];
+
+const badge = language === 'es' ? 'Líder Arquitecto' : 'Architect Leader';
+const tagline = language === 'es'
+  ? 'Equipos de alto rendimiento a través de ingeniería centrada en personas.'
+  : 'Building high-performance teams through people-centric engineering.';
+const ctaText = language === 'es' ? 'Conocer más' : 'Learn more';
+const ctaHref = `/${language}/about`;
+---
+
+<section class="hero" aria-label={badge}>
+  <div class="hero__portrait">
+    <img
+      src="/images/manufosela/manufosela1280.webp"
+      srcset="/images/manufosela/manufosela320.webp 320w,
+              /images/manufosela/manufosela460.webp 460w,
+              /images/manufosela/manufosela480.webp 480w,
+              /images/manufosela/manufosela768.webp 768w,
+              /images/manufosela/manufosela1280.webp 1280w"
+      sizes="(min-width: 1024px) 55vw, 100vw"
+      alt={altText}
+      width="1280"
+      height="1600"
+      loading="eager"
+      fetchpriority="high"
+      decoding="async"
+    />
+  </div>
+
+  <div class="hero__overlay" aria-hidden="true"></div>
+
+  <div class="hero__content">
+    <span class="hero__badge">{badge}</span>
+    <h1 class="hero__title">{person.name}</h1>
+    <p class="hero__role">{person.position}</p>
+    <p class="hero__tagline">{tagline}</p>
+    <a href={ctaHref} class="hero__cta">
+      {ctaText}
+      <span class="hero__cta-line" aria-hidden="true"></span>
+    </a>
+  </div>
+</section>
+
+<style>
+  .hero {
+    position: relative;
+    display: grid;
+    min-height: calc(100dvh - 4rem);
+    overflow: hidden;
+    background-color: var(--surface);
+  }
+
+  .hero__portrait {
+    grid-area: 1 / 1;
+  }
+  .hero__portrait img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: center 20%;
+    filter: grayscale(1) contrast(1.15);
+    aspect-ratio: 4 / 5;
+  }
+
+  .hero__overlay {
+    grid-area: 1 / 1;
+    background:
+      radial-gradient(
+        ellipse 120% 80% at 0% 100%,
+        var(--surface) 0%,
+        color-mix(in srgb, var(--surface) 85%, transparent) 30%,
+        color-mix(in srgb, var(--surface) 40%, transparent) 55%,
+        transparent 80%
+      );
+    z-index: 1;
+  }
+
+  .hero__content {
+    grid-area: 1 / 1;
+    z-index: 2;
+    align-self: end;
+    padding: clamp(2rem, 6vw, 4rem);
+    padding-bottom: clamp(3rem, 8vh, 5rem);
+    max-width: 32rem;
+  }
+
+  .hero__badge {
+    display: inline-block;
+    font-family: 'Inter', sans-serif;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--primary-fixed-dim);
+    margin-bottom: 1.25rem;
+  }
+
+  .hero__title {
+    font-family: 'Manrope', sans-serif;
+    font-size: clamp(2.75rem, 8vw, 4.5rem);
+    font-weight: 900;
+    letter-spacing: -0.03em;
+    line-height: 0.95;
+    color: var(--on-surface);
+    margin-bottom: 0.75rem;
+  }
+
+  .hero__role {
+    font-family: 'Inter', sans-serif;
+    font-size: clamp(0.8125rem, 1.5vw, 0.9375rem);
+    font-weight: 400;
+    color: var(--on-surface-variant);
+    margin-bottom: clamp(1.5rem, 4vh, 2.5rem);
+    line-height: 1.5;
+  }
+
+  .hero__tagline {
+    font-family: 'Inter', sans-serif;
+    font-size: clamp(0.9375rem, 1.8vw, 1.0625rem);
+    font-weight: 400;
+    line-height: 1.6;
+    color: var(--on-surface-variant);
+    max-width: 26rem;
+    margin-bottom: clamp(2rem, 5vh, 3rem);
+  }
+
+  .hero__cta {
+    position: relative;
+    display: inline-block;
+    font-family: 'Inter', sans-serif;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--on-surface);
+    text-decoration: none;
+    padding-bottom: 0.375rem;
+    transition: color 240ms var(--ease-3);
+  }
+  .hero__cta:hover {
+    color: var(--primary-fixed-dim);
+  }
+  .hero__cta:active {
+    transform: scale(0.97);
+  }
+  .hero__cta-line {
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    width: 2rem;
+    height: 1px;
+    background-color: var(--primary-fixed-dim);
+    transition: width 320ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  .hero__cta:hover .hero__cta-line {
+    width: 100%;
+  }
+
+  @media (min-width: 1024px) {
+    .hero {
+      grid-template-columns: 55fr 45fr;
+      min-height: calc(100dvh - 4rem);
+    }
+
+    .hero__portrait {
+      grid-area: 1 / 1;
+    }
+    .hero__portrait img {
+      aspect-ratio: auto;
+      height: 100%;
+    }
+
+    .hero__overlay {
+      grid-area: 1 / 1;
+      background:
+        linear-gradient(
+          to right,
+          transparent 70%,
+          var(--surface) 100%
+        );
+    }
+
+    .hero__content {
+      grid-area: 1 / 2;
+      align-self: center;
+      padding: clamp(3rem, 5vw, 5rem);
+      max-width: none;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .hero__cta,
+    .hero__cta-line {
+      transition: none;
+    }
+  }
+</style>

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -1,6 +1,6 @@
 ---
 import Layout from '~/layouts/Layout.astro';
-import Card from '~/components/Card.astro';
+import HeroHome from '~/components/HeroHome.astro';
 import { Site } from '~/data/config';
 
 const title = Site.title;
@@ -8,5 +8,5 @@ const language = 'en';
 ---
 
 <Layout {title} includeSchema={true} active="home">
-  <Card language={language} />
+  <HeroHome language={language} />
 </Layout>

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -1,6 +1,6 @@
 ---
 import Layout from '~/layouts/Layout.astro';
-import Card from '~/components/Card.astro';
+import HeroHome from '~/components/HeroHome.astro';
 import { Site } from '~/data/config';
 
 const title = Site.title;
@@ -8,5 +8,5 @@ const language = 'es';
 ---
 
 <Layout {title} includeSchema={true} active="home">
-  <Card language={language} />
+  <HeroHome language={language} />
 </Layout>


### PR DESCRIPTION
## Summary
- New \`HeroHome.astro\` component replacing the legacy \`Card.astro\` on home pages
- Full-bleed portrait with grayscale + contrast(1.15) as hero background
- Mobile: radial gradient overlay, text over image at bottom-left
- Desktop ≥1024: asymmetric 55/45 grid, portrait left, text right
- Editorial CTA (text + expanding mint underline on hover)
- LCP optimised: eager loading, fetchpriority high, srcset × 5, aspect-ratio 4/5

## Test plan
- [x] \`npm run build\` passes (18 pages)
- [ ] Mobile: portrait fills viewport, text readable over gradient
- [ ] Desktop: 55/45 split, text vertically centered
- [ ] CTA underline expands on hover
- [ ] LCP < 2.5s with eager/fetchpriority

Card: MFS-TSK-0009