### PR TITLE
feat(home): add Social Proof logo strip [MFS-TSK-0012]

### DIFF
--- a/src/components/SocialProof.astro
+++ b/src/components/SocialProof.astro
@@ -1,0 +1,85 @@
+---
+import { socialProof } from '~/data/socialproof';
+
+interface Props {
+  language: 'es' | 'en';
+}
+
+const { language } = Astro.props;
+const label = socialProof[language].label;
+const logos = socialProof.logos;
+---
+
+<section class="social-proof" aria-label={label}>
+  <p class="social-proof__label">{label}</p>
+  <div class="social-proof__strip">
+    {logos.map((logo) => (
+      <span class="social-proof__logo" style={`--logo-w: ${logo.width}px`}>
+        {logo.name}
+      </span>
+    ))}
+  </div>
+</section>
+
+<style>
+  .social-proof {
+    padding-block: clamp(2.5rem, 6vh, 4rem);
+    border-top: 1px solid color-mix(in srgb, var(--outline-variant) 10%, transparent);
+    max-width: 1280px;
+    margin-inline: auto;
+    padding-inline: clamp(1.5rem, 4vw, 3rem);
+  }
+
+  .social-proof__label {
+    font-family: 'Inter', sans-serif;
+    font-size: 0.625rem;
+    font-weight: 600;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--on-surface-variant);
+    text-align: center;
+    margin-bottom: clamp(1.5rem, 4vh, 2.5rem);
+  }
+
+  .social-proof__strip {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    gap: clamp(2rem, 5vw, 3.5rem);
+  }
+
+  .social-proof__logo {
+    font-family: 'Manrope', sans-serif;
+    font-size: clamp(0.875rem, 1.5vw, 1rem);
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    color: var(--on-surface-variant);
+    opacity: 0.35;
+    transition: opacity 300ms var(--ease-3);
+    white-space: nowrap;
+    user-select: none;
+  }
+
+  .social-proof__logo:hover {
+    opacity: 0.7;
+  }
+
+  @media (max-width: 640px) {
+    .social-proof__strip {
+      overflow-x: auto;
+      flex-wrap: nowrap;
+      justify-content: flex-start;
+      padding-inline: 0.5rem;
+      -webkit-overflow-scrolling: touch;
+      scrollbar-width: none;
+    }
+    .social-proof__strip::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .social-proof__logo { transition: none; }
+  }
+</style>

--- a/src/data/socialproof.js
+++ b/src/data/socialproof.js
@@ -1,0 +1,13 @@
+export const socialProof = {
+  es: { label: 'Colaboraciones y liderazgo' },
+  en: { label: 'Collaborations & Leadership' },
+  logos: [
+    { name: 'Orange', width: 90 },
+    { name: 'Kairós DS', width: 80 },
+    { name: 'Lean Mind', width: 90 },
+    { name: 'Geniova', width: 80 },
+    { name: 'Mirai', width: 65 },
+    { name: 'Codemotion', width: 100 },
+    { name: 'CommitConf', width: 95 }
+  ]
+};

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -3,6 +3,7 @@ import Layout from '~/layouts/Layout.astro';
 import HeroHome from '~/components/HeroHome.astro';
 import Dualidad from '~/components/Dualidad.astro';
 import BentoLogros from '~/components/BentoLogros.astro';
+import SocialProof from '~/components/SocialProof.astro';
 import { Site } from '~/data/config';
 
 const title = Site.title;
@@ -14,6 +15,7 @@ const language = 'en';
   <div class="home-sections">
     <Dualidad language={language} />
     <BentoLogros language={language} />
+    <SocialProof language={language} />
   </div>
 </Layout>
 

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -3,6 +3,7 @@ import Layout from '~/layouts/Layout.astro';
 import HeroHome from '~/components/HeroHome.astro';
 import Dualidad from '~/components/Dualidad.astro';
 import BentoLogros from '~/components/BentoLogros.astro';
+import SocialProof from '~/components/SocialProof.astro';
 import { Site } from '~/data/config';
 
 const title = Site.title;
@@ -14,6 +15,7 @@ const language = 'es';
   <div class="home-sections">
     <Dualidad language={language} />
     <BentoLogros language={language} />
+    <SocialProof language={language} />
   </div>
 </Layout>
 


### PR DESCRIPTION
## Summary
- \`SocialProof.astro\` + \`socialproof.js\`: typographic logo strip
- 7 collaboration names at 35% opacity, hover to 70%
- Mobile: horizontal scroll; Desktop: centered flex-wrap
- Closes EPIC-03 (Home Líder Arquitecto — 4/4 tasks)

Card: MFS-TSK-0012