### PR TITLE
fix: unregister stale service worker and remove manifest

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -13,9 +13,6 @@ const { includeSchema = false } = Astro.props;
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <link rel="shortcut icon" href="/favicon.ico" />
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-<link rel="manifest" href="/site.webmanifest" />
-
-<meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 <meta name="apple-mobile-web-app-title" content="manufosela.es" />
 <meta name="application-name" content="manufosela.es" />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -41,6 +41,16 @@ const lang = Astro.url.pathname.startsWith('/en') ? 'en' : 'es';
         src: url('/fonts/manrope-variable.woff2') format('woff2-variations');
       }
     </style>
+    <script is:inline>
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.getRegistrations().then(function(regs) {
+          regs.forEach(function(r) { r.unregister(); });
+        });
+        caches.keys().then(function(names) {
+          names.forEach(function(n) { caches.delete(n); });
+        });
+      }
+    </script>
   </head>
   <body>
     <Header active={active} language={lang} />


### PR DESCRIPTION
## Summary
- Inline script in Layout to unregister all service workers + clear caches
- Remove \`<link rel="manifest">\` from BaseHead (no PWA needed)
- Fixes stale cache preventing new redesign from showing

## Test plan
- [ ] Open site → DevTools → Application → check no SW registered
- [ ] Hard refresh shows the new HeroHome + Dualidad + Bento + SocialProof