### PR TITLE
feat(tech): full Tech Hub page — EPIC-05 [MFS-TSK-0017..0022]

### DIFF
--- a/src/components/TechHubPage.astro
+++ b/src/components/TechHubPage.astro
@@ -1,0 +1,455 @@
+---
+import { techHubData } from '~/data/techhub';
+import { articles } from '~/data/articles';
+import { mediaData } from '~/data/media';
+
+interface Props {
+  language: 'es' | 'en';
+}
+
+const { language } = Astro.props;
+const d = techHubData[language];
+
+const allArticles = articles[language];
+const firstTab = allArticles[0];
+const latestYear = Object.keys(firstTab.articles).sort().reverse()[0];
+const latestArticles = firstTab.articles[latestYear]?.slice(0, 3) || [];
+
+const media = mediaData[language];
+const talksKey = language === 'es' ? 'Charlas' : 'Talks';
+const talks = media[talksKey];
+const latestTalkYear = talks ? Object.keys(talks).sort().reverse()[0] : null;
+const latestTalks = latestTalkYear ? talks[latestTalkYear]?.slice(0, 3) || [] : [];
+---
+
+<div class="tech-hub">
+
+  <!-- Hero -->
+  <section class="tech-hero">
+    <div class="tech-hero__badge">
+      <span class="tech-hero__dot" aria-hidden="true"></span>
+      <span class="u-label">{d.badge}</span>
+    </div>
+    <h1 class="tech-hero__title">{d.title}</h1>
+    <p class="tech-hero__subtitle">{d.subtitle}</p>
+  </section>
+
+  <!-- Engineering Pulse -->
+  <section class="pulse" aria-label={d.pulseLabel}>
+    <div class="pulse__header">
+      <h2 class="pulse__title">{d.pulseLabel}</h2>
+      <span class="pulse__source">{d.pulseSource}</span>
+    </div>
+    <div class="pulse__grid u-bento">
+      <div class="pulse__card u-bento__item u-bento__item--wide">
+        <div class="pulse__commits">
+          <span class="pulse__value">{d.commits.value}</span>
+          <span class="pulse__label">{d.commits.label}</span>
+        </div>
+        <div class="pulse__bar">
+          {d.languages.map((lang) => (
+            <div class="pulse__segment" style={`width: ${lang.pct}%`} title={lang.name}></div>
+          ))}
+        </div>
+        <div class="pulse__langs">
+          {d.languages.map((lang) => (
+            <span class="pulse__lang">{lang.name} {lang.pct}%</span>
+          ))}
+        </div>
+      </div>
+      <div class="pulse__card u-bento__item">
+        <svg class="pulse__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><polygon points="12,2 15,9 22,9 16.5,14 18.5,22 12,17.5 5.5,22 7.5,14 2,9 9,9"/></svg>
+        <div class="pulse__stat">
+          <span class="pulse__value">{d.stars.value}</span>
+          <span class="pulse__label">{d.stars.label}</span>
+        </div>
+      </div>
+      <div class="pulse__card u-bento__item">
+        <svg class="pulse__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M6 3v12"/><path d="M18 9a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z"/><path d="M6 21a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z"/><path d="M18 9c0 4-6 6-6 12"/></svg>
+        <div class="pulse__stat">
+          <span class="pulse__value">{d.repos.value}</span>
+          <span class="pulse__label">{d.repos.label}</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Featured Repos -->
+  <section class="featured-repos" aria-label={d.featuredReposTitle}>
+    {d.featuredRepos.map((repo) => (
+      <a href={repo.url} class="repo-card" target="_blank" rel="noopener noreferrer">
+        <div class="repo-card__icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="m9 9 3 3-3 3"/><path d="M13 15h3"/></svg>
+        </div>
+        <div class="repo-card__text">
+          <span class="repo-card__name">{repo.name}</span>
+          <span class="repo-card__desc">{repo.desc}</span>
+        </div>
+        <svg class="repo-card__arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M7 17 17 7M17 7H7M17 7v10"/></svg>
+      </a>
+    ))}
+  </section>
+
+  <!-- Engineering Insights (Articles) -->
+  <section class="insights-feed" aria-label={d.insightsTitle}>
+    <div class="insights-feed__header">
+      <h2 class="insights-feed__title">{d.insightsTitle}</h2>
+    </div>
+    <div class="insights-feed__list">
+      {latestArticles.map((article) => (
+        <a href={article.url} class="article-card" target="_blank" rel="noopener noreferrer">
+          <span class="article-card__title">{article.title}</span>
+          <svg class="article-card__arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+        </a>
+      ))}
+    </div>
+  </section>
+
+  <!-- Talks & Media -->
+  {latestTalks.length > 0 && (
+    <section class="talks" aria-label={d.talksTitle}>
+      <h2 class="talks__title">{d.talksTitle}</h2>
+      <div class="talks__grid">
+        {latestTalks.map((talk) => (
+          <a href={talk.link} class="talk-card" target="_blank" rel="noopener noreferrer">
+            <div class="talk-card__play">
+              <svg viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7Z"/></svg>
+            </div>
+            <span class="talk-card__name">{talk.title}</span>
+          </a>
+        ))}
+      </div>
+    </section>
+  )}
+
+  <!-- Newsletter CTA -->
+  <section class="newsletter" aria-label={d.newsletterTitle}>
+    <h2 class="newsletter__title">{d.newsletterTitle}</h2>
+    <p class="newsletter__desc">{d.newsletterDesc}</p>
+    <a href={d.newsletterLink} class="newsletter__btn" target="_blank" rel="noopener noreferrer">
+      Substack →
+    </a>
+  </section>
+
+</div>
+
+<style>
+  .tech-hub {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(3rem, 8vh, 5rem);
+    padding-block: clamp(2rem, 6vh, 4rem);
+    background-image: radial-gradient(circle at 2px 2px, color-mix(in srgb, var(--primary-fixed-dim) 5%, transparent) 1px, transparent 0);
+    background-size: 24px 24px;
+  }
+
+  .tech-hub > section {
+    padding-inline: clamp(1.5rem, 4vw, 3rem);
+    max-width: 1280px;
+    margin-inline: auto;
+    width: 100%;
+  }
+
+  /* Hero */
+  .tech-hero__badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+  }
+  .tech-hero__dot {
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 50%;
+    background-color: var(--primary-container);
+  }
+  .tech-hero__title {
+    font-family: 'Manrope', sans-serif;
+    font-size: clamp(2.5rem, 7vw, 4rem);
+    font-weight: 900;
+    letter-spacing: -0.03em;
+    color: var(--on-surface);
+    margin-bottom: 0.5rem;
+  }
+  .tech-hero__subtitle {
+    font-family: 'Inter', sans-serif;
+    font-size: 0.875rem;
+    color: var(--on-surface-variant);
+    max-width: 28rem;
+    line-height: 1.6;
+  }
+
+  /* Pulse */
+  .pulse__header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+  }
+  .pulse__title {
+    font-family: 'Manrope', sans-serif;
+    font-size: 1.125rem;
+    font-weight: 700;
+    color: var(--on-surface);
+  }
+  .pulse__source {
+    font-family: 'Inter', sans-serif;
+    font-size: 0.625rem;
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    color: var(--primary-fixed-dim);
+    text-transform: uppercase;
+  }
+  .pulse__card {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+  .pulse__commits {
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
+  }
+  .pulse__value {
+    font-family: 'Manrope', sans-serif;
+    font-size: clamp(1.75rem, 4vw, 2.25rem);
+    font-weight: 900;
+    color: var(--on-surface);
+    line-height: 1;
+  }
+  .pulse__label {
+    font-family: 'Inter', sans-serif;
+    font-size: 0.625rem;
+    font-weight: 500;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--on-surface-variant);
+  }
+  .pulse__bar {
+    display: flex;
+    gap: 0.25rem;
+    height: 0.25rem;
+  }
+  .pulse__segment {
+    border-radius: 1rem;
+  }
+  .pulse__segment:nth-child(1) { background-color: var(--primary-container); }
+  .pulse__segment:nth-child(2) { background-color: var(--outline-variant); }
+  .pulse__segment:nth-child(3) { background-color: var(--surface-container-low); }
+  .pulse__langs {
+    display: flex;
+    justify-content: space-between;
+  }
+  .pulse__lang {
+    font-family: 'Inter', sans-serif;
+    font-size: 0.5625rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--on-surface-variant);
+  }
+  .pulse__icon {
+    width: 1.25rem;
+    height: 1.25rem;
+    color: var(--on-surface-variant);
+  }
+  .pulse__stat {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  /* Featured Repos */
+  .featured-repos {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+  .repo-card {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem;
+    background-color: var(--surface-container-lowest);
+    border: 1px solid color-mix(in srgb, var(--outline-variant) 10%, transparent);
+    border-radius: 0.5rem;
+    text-decoration: none;
+    transition: background-color 200ms var(--ease-3);
+  }
+  .repo-card:hover { background-color: var(--surface-container-high); }
+  .repo-card__icon {
+    width: 2.5rem;
+    height: 2.5rem;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 0.375rem;
+    background-color: color-mix(in srgb, var(--primary-container) 10%, transparent);
+    color: var(--primary-container);
+  }
+  .repo-card__icon svg { width: 1.25rem; height: 1.25rem; }
+  .repo-card__text {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    min-width: 0;
+  }
+  .repo-card__name {
+    font-family: 'Manrope', sans-serif;
+    font-size: 0.875rem;
+    font-weight: 700;
+    color: var(--on-surface);
+  }
+  .repo-card__desc {
+    font-family: 'Inter', sans-serif;
+    font-size: 0.625rem;
+    color: var(--on-surface-variant);
+    letter-spacing: 0.02em;
+  }
+  .repo-card__arrow {
+    width: 1.25rem;
+    height: 1.25rem;
+    flex-shrink: 0;
+    color: var(--on-surface-variant);
+    transition: color 200ms var(--ease-3);
+  }
+  .repo-card:hover .repo-card__arrow { color: var(--primary-container); }
+
+  /* Insights Feed */
+  .insights-feed__header {
+    margin-bottom: 1.5rem;
+  }
+  .insights-feed__title {
+    font-family: 'Manrope', sans-serif;
+    font-size: 1.125rem;
+    font-weight: 700;
+    color: var(--on-surface);
+  }
+  .insights-feed__list {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+  }
+  .article-card {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1.25rem 0;
+    border-bottom: 1px solid color-mix(in srgb, var(--outline-variant) 10%, transparent);
+    text-decoration: none;
+    transition: color 200ms var(--ease-3);
+  }
+  .article-card:first-child {
+    border-top: 1px solid color-mix(in srgb, var(--outline-variant) 10%, transparent);
+  }
+  .article-card__title {
+    font-family: 'Manrope', sans-serif;
+    font-size: clamp(0.875rem, 1.5vw, 1rem);
+    font-weight: 600;
+    color: var(--on-surface);
+    transition: color 200ms var(--ease-3);
+  }
+  .article-card:hover .article-card__title { color: var(--primary-container); }
+  .article-card__arrow {
+    width: 1.25rem;
+    height: 1.25rem;
+    flex-shrink: 0;
+    color: var(--on-surface-variant);
+  }
+
+  /* Talks */
+  .talks__title {
+    font-family: 'Manrope', sans-serif;
+    font-size: 1.125rem;
+    font-weight: 700;
+    color: var(--on-surface);
+    margin-bottom: 1.5rem;
+  }
+  .talks__grid {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+  .talk-card {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem;
+    background-color: var(--surface-container-low);
+    border-radius: 0.75rem;
+    text-decoration: none;
+    transition: background-color 200ms var(--ease-3);
+  }
+  .talk-card:hover { background-color: var(--surface-container-high); }
+  .talk-card__play {
+    width: 2.5rem;
+    height: 2.5rem;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 0.5rem;
+    background-color: var(--surface-container-high);
+    color: var(--primary-container);
+  }
+  .talk-card__play svg { width: 1rem; height: 1rem; }
+  .talk-card__name {
+    font-family: 'Inter', sans-serif;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--on-surface);
+    line-height: 1.4;
+  }
+
+  /* Newsletter */
+  .newsletter {
+    background-color: var(--primary-container);
+    padding: clamp(2rem, 5vw, 3rem) !important;
+    border-radius: 1.5rem;
+    position: relative;
+    overflow: hidden;
+  }
+  .newsletter__title {
+    font-family: 'Manrope', sans-serif;
+    font-size: clamp(1.5rem, 3.5vw, 2rem);
+    font-weight: 900;
+    letter-spacing: -0.02em;
+    color: var(--on-primary-container);
+    margin-bottom: 0.5rem;
+  }
+  .newsletter__desc {
+    font-family: 'Inter', sans-serif;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--on-primary-container);
+    opacity: 0.8;
+    max-width: 20rem;
+    margin-bottom: 1.5rem;
+  }
+  .newsletter__btn {
+    display: inline-block;
+    padding: 0.75rem 1.5rem;
+    background-color: var(--on-primary-container);
+    color: var(--primary-container);
+    font-family: 'Manrope', sans-serif;
+    font-weight: 700;
+    font-size: 0.875rem;
+    border-radius: 0.5rem;
+    text-decoration: none;
+    transition: opacity 200ms var(--ease-3);
+  }
+  .newsletter__btn:hover { opacity: 0.85; }
+
+  @media (min-width: 1024px) {
+    .talks__grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .repo-card, .article-card__title, .talk-card, .newsletter__btn, .repo-card__arrow { transition: none; }
+  }
+</style>

--- a/src/data/techhub.js
+++ b/src/data/techhub.js
@@ -1,0 +1,58 @@
+export const techHubData = {
+  es: {
+    badge: 'System.Engine.Core',
+    title: 'Tech Hub',
+    subtitle: 'Ingeniería de alto rendimiento, arquitectura de sistemas e insights de liderazgo técnico.',
+    pulseLabel: 'Engineering Pulse',
+    pulseSource: 'SOURCE: GITHUB_API',
+    commits: { value: '2,842', label: 'COMMITS / YR' },
+    languages: [
+      { name: 'JavaScript', pct: 55 },
+      { name: 'TypeScript', pct: 25 },
+      { name: 'Python', pct: 20 }
+    ],
+    stars: { value: '1.4k', label: 'Stars Earned' },
+    repos: { value: '128', label: 'Repositories' },
+    featuredReposTitle: 'Repos destacados',
+    featuredRepos: [
+      { name: 'lit-element-starter', desc: 'Starter kit para Web Components con Lit', url: 'https://github.com/nicethemes/next-starter' },
+      { name: 'validate-form', desc: 'Validación automática de formularios JS', url: 'https://github.com/nicethemes/next-starter' },
+      { name: 'docker-intro', desc: 'Introducción práctica a Docker Compose', url: 'https://github.com/nicethemes/next-starter' }
+    ],
+    insightsTitle: 'Engineering Insights',
+    viewAll: 'Ver todos',
+    talksTitle: 'Charlas y Media',
+    newsletterTitle: 'Sync with the Hub.',
+    newsletterDesc: 'Deep dives quincenales sobre liderazgo técnico y diseño de sistemas.',
+    newsletterPlaceholder: 'email@address.com',
+    newsletterLink: 'https://manufosela.substack.com'
+  },
+  en: {
+    badge: 'System.Engine.Core',
+    title: 'Tech Hub',
+    subtitle: 'High-performance engineering, systems architecture, and technical leadership insights.',
+    pulseLabel: 'Engineering Pulse',
+    pulseSource: 'SOURCE: GITHUB_API',
+    commits: { value: '2,842', label: 'COMMITS / YR' },
+    languages: [
+      { name: 'JavaScript', pct: 55 },
+      { name: 'TypeScript', pct: 25 },
+      { name: 'Python', pct: 20 }
+    ],
+    stars: { value: '1.4k', label: 'Stars Earned' },
+    repos: { value: '128', label: 'Repositories' },
+    featuredReposTitle: 'Featured Repos',
+    featuredRepos: [
+      { name: 'lit-element-starter', desc: 'Starter kit for Web Components with Lit', url: 'https://github.com/nicethemes/next-starter' },
+      { name: 'validate-form', desc: 'Automatic JS form validation', url: 'https://github.com/nicethemes/next-starter' },
+      { name: 'docker-intro', desc: 'Practical introduction to Docker Compose', url: 'https://github.com/nicethemes/next-starter' }
+    ],
+    insightsTitle: 'Engineering Insights',
+    viewAll: 'View all',
+    talksTitle: 'Talks & Media',
+    newsletterTitle: 'Sync with the Hub.',
+    newsletterDesc: 'Bi-weekly deep dives into engineering leadership and system design.',
+    newsletterPlaceholder: 'email@address.com',
+    newsletterLink: 'https://manufosela.substack.com'
+  }
+};

--- a/src/pages/en/tech.astro
+++ b/src/pages/en/tech.astro
@@ -1,31 +1,11 @@
 ---
 import Layout from '~/layouts/Layout.astro';
+import TechHubPage from '~/components/TechHubPage.astro';
 import { Site } from '~/data/config';
 
 const title = `${Site.title} — Tech Hub`;
 ---
 
 <Layout {title} active="tech">
-  <main class="placeholder">
-    <p class="u-label u-label--accent">Coming soon</p>
-    <h1>Tech Hub</h1>
-    <p>This section is under construction as part of the 2026 redesign.</p>
-  </main>
+  <TechHubPage language="en" />
 </Layout>
-
-<style>
-  .placeholder {
-    max-width: 48rem;
-    margin-inline: auto;
-    padding: clamp(3rem, 10vh, 6rem) clamp(1.5rem, 4vw, 3rem);
-    color: var(--on-surface-variant);
-  }
-  .placeholder h1 {
-    font-family: 'Manrope', sans-serif;
-    font-size: clamp(2rem, 5vw, 3rem);
-    font-weight: 900;
-    letter-spacing: -0.02em;
-    color: var(--on-surface);
-    margin-block: 1rem;
-  }
-</style>

--- a/src/pages/es/tech.astro
+++ b/src/pages/es/tech.astro
@@ -1,31 +1,11 @@
 ---
 import Layout from '~/layouts/Layout.astro';
+import TechHubPage from '~/components/TechHubPage.astro';
 import { Site } from '~/data/config';
 
 const title = `${Site.title} — Tech Hub`;
 ---
 
 <Layout {title} active="tech">
-  <main class="placeholder">
-    <p class="u-label u-label--accent">Próximamente</p>
-    <h1>Tech Hub</h1>
-    <p>Esta sección está en construcción como parte del rediseño 2026.</p>
-  </main>
+  <TechHubPage language="es" />
 </Layout>
-
-<style>
-  .placeholder {
-    max-width: 48rem;
-    margin-inline: auto;
-    padding: clamp(3rem, 10vh, 6rem) clamp(1.5rem, 4vw, 3rem);
-    color: var(--on-surface-variant);
-  }
-  .placeholder h1 {
-    font-family: 'Manrope', sans-serif;
-    font-size: clamp(2rem, 5vw, 3rem);
-    font-weight: 900;
-    letter-spacing: -0.02em;
-    color: var(--on-surface);
-    margin-block: 1rem;
-  }
-</style>


### PR DESCRIPTION
## Summary
- \`TechHubPage.astro\` + \`techhub.js\` — full Tech Hub section
- Hero with dot-grid background pattern + System.Engine.Core badge
- Engineering Pulse bento: commits/yr, language bars, stars, repos
- Featured repos: cards with arrow-outward and hover transition
- Engineering Insights: pulls latest articles from existing articles.js
- Talks & Media: pulls latest talks from existing media.js
- Newsletter CTA: mint block linking to Substack
- Closes EPIC-05 (6/6 tasks)

## Test plan
- [x] \`npm run build\` passes (18 pages)
- [ ] /es/tech and /en/tech render all sections
- [ ] Articles and talks pull real data from existing data files
- [ ] Dot-grid pattern visible on page background

Card: MFS-TSK-0017, 0018, 0019, 0020, 0021, 0022