### PR TITLE
fix(qa): accessibility fixes + EsEnToggle redesign — EPIC-08 [MFS-TSK-0029]

### DIFF
--- a/src/components/EsEnToggle.astro
+++ b/src/components/EsEnToggle.astro
@@ -2,92 +2,78 @@
 
 ---
 
-<section class="language-toggle">
-  <input type="checkbox" id="toggle-lang" class="toggle-lang" />
-  <label for="toggle-lang" class="button-lang" aria-label="Toggle Spanish and English mode"></label>
-</section>
+<div class="lang-switch" role="radiogroup" aria-label="Language">
+  <a
+    href="#"
+    class="lang-switch__option"
+    data-lang="es"
+    aria-label="Español"
+  >ES</a>
+  <span class="lang-switch__sep" aria-hidden="true">/</span>
+  <a
+    href="#"
+    class="lang-switch__option"
+    data-lang="en"
+    aria-label="English"
+  >EN</a>
+</div>
 
 <script>
-  const lang = document.location.pathname.includes('/en/') ? 'EN' : 'ES';
-  let toggleLanguage: HTMLInputElement | null;
+  const langSwitch = document.querySelectorAll<HTMLAnchorElement>('.lang-switch__option');
+  const currentLang = document.location.pathname.includes('/en/') ? 'en' : 'es';
 
-  function init() {
-    toggleLanguage = document.querySelector('#toggle-lang');
-    if (toggleLanguage) {
-      toggleLanguage.addEventListener('change', toggleLangHandler);
-      setLanguageBasedOnPreference(lang);
-    }
-  }
-
-  function setLanguageBasedOnPreference(lang: string) {
-    if (toggleLanguage) {
-      toggleLanguage.checked = lang === 'EN';
-    }
-    document.documentElement.setAttribute('lang', lang);
-  }
-
-  function toggleLangHandler() {
-    const newLanguage = toggleLanguage?.checked ? 'EN' : 'ES';
-    const currentPath = window.location.pathname;
-
-    let newPath = '';
-
-    if (currentPath === '/' || currentPath === '/es/' || currentPath === '/en/') {
-      newPath = newLanguage === 'EN' ? '/en/' : '/';
-    } else {
-      const segments = currentPath.split('/');
-      if (newLanguage === 'EN') {
-        segments[1] = 'en';
-      } else {
-        segments[1] = 'es';
-      }
-      newPath = segments.join('/');
+  langSwitch.forEach((link) => {
+    const lang = link.dataset.lang;
+    if (lang === currentLang) {
+      link.classList.add('lang-switch__option--active');
+      link.setAttribute('aria-current', 'true');
     }
 
-    document.documentElement.setAttribute('lang', newLanguage);
-    window.location.href = newPath;
-  }
-
-  document.addEventListener('DOMContentLoaded', init);
+    link.addEventListener('click', (e) => {
+      e.preventDefault();
+      if (lang === currentLang) return;
+      const segments = window.location.pathname.split('/');
+      segments[1] = lang || 'es';
+      window.location.href = segments.join('/');
+    });
+  });
 </script>
 
 <style>
-  .language-toggle {
-    padding: 1rem;
-    z-index: 5;
+  .lang-switch {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
   }
 
-  .language-toggle .toggle-lang {
-    display: none;
+  .lang-switch__option {
+    font-family: 'Inter', sans-serif;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-decoration: none;
+    color: var(--on-surface-variant);
+    padding: 0.375rem 0.5rem;
+    border-radius: 0.25rem;
+    transition: color 200ms var(--ease-3), background-color 200ms var(--ease-3);
   }
 
-  .language-toggle .button-lang {
-    display: inline-block;
-    width: 90px;
-    height: 44px;
-    background: var(--primary-color);
-    border-radius: 30px;
-    position: relative;
-    cursor: pointer;
+  .lang-switch__option:hover {
+    color: var(--on-surface);
   }
 
-  .language-toggle .button-lang::after {
-    content: 'ES';
-    width: 30px;
-    height: 44px;
-    position: absolute;
-    top: 0;
-    left: 10px;
-    display: grid;
-    place-content: center;
-    line-height: 0;
-    color: white;
-    font-weight: bold;
-    transition: transform 0.5s ease-in;
+  .lang-switch__option--active {
+    color: var(--on-primary);
+    background-color: var(--primary-fixed-dim);
   }
 
-  .language-toggle .toggle-lang:checked + .button-lang::after {
-    content: 'EN';
-    transform: translateX(40px);
+  .lang-switch__sep {
+    font-size: 0.625rem;
+    color: var(--outline-variant);
+    user-select: none;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .lang-switch__option { transition: none; }
   }
 </style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -320,7 +320,11 @@ const { active = 'home', language = 'es' } = Astro.props;
     drawer.setAttribute('data-open', String(open));
     drawer.setAttribute('aria-hidden', String(!open));
     document.body.style.overflow = open ? 'hidden' : '';
+    drawer.querySelectorAll<HTMLElement>('a, button, input').forEach((el) => {
+      el.tabIndex = open ? 0 : -1;
+    });
   };
+  setDrawer(false);
   burger?.addEventListener('click', () => {
     setDrawer(burger.getAttribute('aria-expanded') !== 'true');
   });

--- a/src/components/SocialProof.astro
+++ b/src/components/SocialProof.astro
@@ -55,7 +55,7 @@ const logos = socialProof.logos;
     font-weight: 700;
     letter-spacing: 0.02em;
     color: var(--on-surface-variant);
-    opacity: 0.35;
+    opacity: 0.5;
     transition: opacity 300ms var(--ease-3);
     white-space: nowrap;
     user-select: none;

--- a/src/components/TechHubPage.astro
+++ b/src/components/TechHubPage.astro
@@ -424,7 +424,6 @@ const latestTalks = latestTalkYear ? talks[latestTalkYear]?.slice(0, 3) || [] : 
     font-size: 0.875rem;
     font-weight: 500;
     color: var(--on-primary-container);
-    opacity: 0.8;
     max-width: 20rem;
     margin-bottom: 1.5rem;
   }

--- a/src/pages/en/contact.astro
+++ b/src/pages/en/contact.astro
@@ -7,5 +7,7 @@ const title = `${Site.title} — Contact`;
 ---
 
 <Layout {title} active="contact">
-  <ContactPage language="en" />
+  <main>
+    <ContactPage language="en" />
+  </main>
 </Layout>

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -11,12 +11,14 @@ const language = 'en';
 ---
 
 <Layout {title} includeSchema={true} active="home">
+  <main>
   <HeroHome language={language} />
   <div class="home-sections">
     <Dualidad language={language} />
     <BentoLogros language={language} />
     <SocialProof language={language} />
   </div>
+  </main>
 </Layout>
 
 <style>

--- a/src/pages/en/leadership.astro
+++ b/src/pages/en/leadership.astro
@@ -7,5 +7,7 @@ const title = `${Site.title} — Affective Leadership`;
 ---
 
 <Layout {title} active="leadership">
-  <LeadershipPage language="en" />
+  <main>
+    <LeadershipPage language="en" />
+  </main>
 </Layout>

--- a/src/pages/en/tech.astro
+++ b/src/pages/en/tech.astro
@@ -7,5 +7,7 @@ const title = `${Site.title} — Tech Hub`;
 ---
 
 <Layout {title} active="tech">
-  <TechHubPage language="en" />
+  <main>
+    <TechHubPage language="en" />
+  </main>
 </Layout>

--- a/src/pages/es/contact.astro
+++ b/src/pages/es/contact.astro
@@ -7,5 +7,7 @@ const title = `${Site.title} — Contacto`;
 ---
 
 <Layout {title} active="contact">
-  <ContactPage language="es" />
+  <main>
+    <ContactPage language="es" />
+  </main>
 </Layout>

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -11,12 +11,14 @@ const language = 'es';
 ---
 
 <Layout {title} includeSchema={true} active="home">
+  <main>
   <HeroHome language={language} />
   <div class="home-sections">
     <Dualidad language={language} />
     <BentoLogros language={language} />
     <SocialProof language={language} />
   </div>
+  </main>
 </Layout>
 
 <style>

--- a/src/pages/es/leadership.astro
+++ b/src/pages/es/leadership.astro
@@ -7,5 +7,7 @@ const title = `${Site.title} — Liderazgo Afectivo`;
 ---
 
 <Layout {title} active="leadership">
-  <LeadershipPage language="es" />
+  <main>
+    <LeadershipPage language="es" />
+  </main>
 </Layout>

--- a/src/pages/es/tech.astro
+++ b/src/pages/es/tech.astro
@@ -7,5 +7,7 @@ const title = `${Site.title} — Tech Hub`;
 ---
 
 <Layout {title} active="tech">
-  <TechHubPage language="es" />
+  <main>
+    <TechHubPage language="es" />
+  </main>
 </Layout>


### PR DESCRIPTION
## Summary
- Fix drawer a11y: tabindex=-1 on hidden focusable elements
- Fix contrast: social proof opacity 0.35→0.5, newsletter desc opacity removed
- Fix landmarks: add \`<main>\` wrapper to all 8 page templates
- Redesign EsEnToggle: replace legacy blue pill with Carbon Mint inline ES/EN links (mint active pill)

## Lighthouse scores (mobile)
| Page | A11y | SEO | Best Practices |
|---|---|---|---|
| Home | 96 | 100 | 77 |
| Leadership | 98 | 100 | 77 |
| Tech | 94 | 100 | 77 |
| Contact | 98 | 100 | 77 |

Best Practices 77 = third-party cookies from Manulitics analytics (not actionable in code).

Card: MFS-TSK-0029