### PR TITLE
fix(admin): global styles for dynamic items

### DIFF
--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -377,7 +377,7 @@ import '~/styles/utilities.css';
     });
   </script>
 
-  <style>
+  <style is:global>
     body { background-color: var(--surface); color: var(--on-surface); font-family: 'Inter', sans-serif; margin: 0; min-height: 100vh; }
     .admin { max-width: 52rem; margin-inline: auto; padding: clamp(1.5rem, 4vw, 3rem); }
     .admin__header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 2rem; padding-bottom: 1rem; border-bottom: 1px solid color-mix(in srgb, var(--outline-variant) 15%, transparent); }


### PR DESCRIPTION
Astro scoped styles use data-astro-cid-xxx attributes that don't reach JS-generated innerHTML. Move admin styles to is:global so list items render with proper CSS.