### PR TITLE
feat: ViewTransitions + fix SVG + correct titles

### DIFF
--- a/src/components/ArticleCatalog.astro
+++ b/src/components/ArticleCatalog.astro
@@ -55,7 +55,7 @@ const years = Object.keys(grouped).sort((a, b) => Number(b) - Number(a));
   )}
 </div>
 
-<style>
+<style is:global>
   .catalog {
     padding-inline: clamp(1.5rem, 4vw, 3rem);
     max-width: 1280px;

--- a/src/components/TechHubPage.astro
+++ b/src/components/TechHubPage.astro
@@ -198,6 +198,48 @@ const viewAllTalks = language === 'es' ? 'Ver todas las charlas' : 'View all tal
 
 </div>
 
+<style is:global>
+  /* Global rules for rehydrated elements (JS innerHTML lacks scoped cids) */
+  .article-card {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1.25rem 0;
+    border-bottom: 1px solid color-mix(in srgb, var(--outline-variant) 10%, transparent);
+    text-decoration: none;
+    transition: color 200ms var(--ease-3);
+  }
+  .article-card:first-child {
+    border-top: 1px solid color-mix(in srgb, var(--outline-variant) 10%, transparent);
+  }
+  .article-card__title {
+    font-family: 'Manrope', sans-serif;
+    font-size: clamp(0.875rem, 1.5vw, 1rem);
+    font-weight: 600;
+    color: var(--on-surface);
+    transition: color 200ms var(--ease-3);
+  }
+  .article-card:hover .article-card__title { color: var(--primary-container); }
+  .article-card__arrow {
+    width: 1.25rem;
+    height: 1.25rem;
+    flex-shrink: 0;
+    color: var(--on-surface-variant);
+  }
+  .repo-card__arrow, .project-card__arrow, .resource-link__arrow {
+    width: 1rem;
+    height: 1rem;
+    flex-shrink: 0;
+  }
+  .catalog__arrow {
+    width: 1rem;
+    height: 1rem;
+    flex-shrink: 0;
+    color: var(--on-surface-variant);
+  }
+</style>
+
 <style>
   .tech-hub {
     display: flex;

--- a/src/data/trajectory.js
+++ b/src/data/trajectory.js
@@ -18,13 +18,13 @@ export const trajectoryData = {
       },
       {
         scope: 'Crecimiento & Cultura',
-        title: 'VP of Engineering en Kairós DS',
+        title: 'Head of Software Development en Kairós DS',
         description: 'Empleado 23. Lideré el crecimiento del equipo técnico, establecí la cultura de ingeniería y llevé la transición hacia arquitecturas modernas. 2015-2023.',
         current: false
       },
       {
         scope: 'Innovación & I+D',
-        title: 'Senior Developer en Orange',
+        title: 'Arquitecto de Software en Orange',
         description: '4 años en I+D investigando tecnologías emergentes, seguidos de desarrollo web en el equipo de producto de la web de Orange.',
         current: false
       }
@@ -55,13 +55,13 @@ export const trajectoryData = {
       },
       {
         scope: 'Growth & Culture',
-        title: 'VP of Engineering at Kairós DS',
+        title: 'Head of Software Development at Kairós DS',
         description: 'Employee #23. Led the growth of the engineering team, established engineering culture and drove the transition towards modern architectures. 2015-2023.',
         current: false
       },
       {
         scope: 'Innovation & R&D',
-        title: 'Senior Developer at Orange',
+        title: 'Software Architect at Orange',
         description: '4 years in R&D researching emerging technologies, followed by web development on the Orange product web team.',
         current: false
       }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,4 +1,5 @@
 ---
+import { ViewTransitions } from 'astro:transitions';
 import BaseHead from '~/components/BaseHead.astro';
 import Header from '~/components/Header.astro';
 import BottomNavBar from '~/components/BottomNavBar.astro';
@@ -24,6 +25,7 @@ const lang = Astro.url.pathname.startsWith('/en') ? 'en' : 'es';
 <html lang={lang}>
   <head>
     <BaseHead title={title} includeSchema={includeSchema} />
+    <ViewTransitions />
     <link rel="preload" href="/fonts/inter-subset.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="/fonts/manrope-variable.woff2" as="font" type="font/woff2" crossorigin />
     <style>


### PR DESCRIPTION
Smooth page transitions via Astro ViewTransitions. Fix giant SVG icons on Tech Hub (caused by rehydrator inner HTML lacking scoped cids). Correct Kairós/Orange titles in trajectory.