### PR TITLE
fix: ViewTransitions → ClientRouter for Astro 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@astrojs/node": "^8.3.4",
     "@types/node": "^20.5.7",
-    "astro": "^4.16.8",
+    "astro": "^6.1.5",
     "astro-compress": "^2.0.14",
     "astro-compressor": "^0.4.0",
     "astro-robots-txt": "^1.0.0",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,5 @@
 ---
-import { ViewTransitions } from 'astro:transitions';
+import { ClientRouter } from 'astro:transitions';
 import BaseHead from '~/components/BaseHead.astro';
 import Header from '~/components/Header.astro';
 import BottomNavBar from '~/components/BottomNavBar.astro';
@@ -25,7 +25,7 @@ const lang = Astro.url.pathname.startsWith('/en') ? 'en' : 'es';
 <html lang={lang}>
   <head>
     <BaseHead title={title} includeSchema={includeSchema} />
-    <ViewTransitions />
+    <ClientRouter />
     <link rel="preload" href="/fonts/inter-subset.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="/fonts/manrope-variable.woff2" as="font" type="font/woff2" crossorigin />
     <style>


### PR DESCRIPTION
Astro 6 renamed ViewTransitions to ClientRouter. Build was failing silently, so the last successful build lacked the new /es/about page.