### PR TITLE
fix: event delegation for scripts + social proof wrap

### DIFF
--- a/src/components/Dualidad.astro
+++ b/src/components/Dualidad.astro
@@ -186,24 +186,21 @@ const d = dualidad[language];
 </style>
 
 <script>
-  const tabs = document.querySelectorAll<HTMLButtonElement>('.dualidad__tab');
-  const panels = document.querySelectorAll<HTMLElement>('.dualidad__panel');
+  // Event delegation: survives ClientRouter transitions without rebinding
+  document.addEventListener('click', (e) => {
+    const tab = (e.target as HTMLElement).closest<HTMLButtonElement>('.dualidad__tab');
+    if (!tab) return;
 
-  tabs.forEach((tab) => {
-    tab.addEventListener('click', () => {
-      const target = tab.dataset.panel;
-
-      tabs.forEach((t) => {
-        const isActive = t === tab;
-        t.classList.toggle('dualidad__tab--active', isActive);
-        t.setAttribute('aria-selected', String(isActive));
-      });
-
-      panels.forEach((p) => {
-        const show = p.id === `panel-${target}`;
-        p.classList.toggle('dualidad__panel--visible', show);
-        p.hidden = !show;
-      });
+    const target = tab.dataset.panel;
+    document.querySelectorAll<HTMLButtonElement>('.dualidad__tab').forEach((t) => {
+      const isActive = t === tab;
+      t.classList.toggle('dualidad__tab--active', isActive);
+      t.setAttribute('aria-selected', String(isActive));
+    });
+    document.querySelectorAll<HTMLElement>('.dualidad__panel').forEach((p) => {
+      const show = p.id === `panel-${target}`;
+      p.classList.toggle('dualidad__panel--visible', show);
+      p.hidden = !show;
     });
   });
 </script>

--- a/src/components/EsEnToggle.astro
+++ b/src/components/EsEnToggle.astro
@@ -19,23 +19,30 @@
 </div>
 
 <script>
-  const langSwitch = document.querySelectorAll<HTMLAnchorElement>('.lang-switch__option');
-  const currentLang = document.location.pathname.includes('/en/') ? 'en' : 'es';
-
-  langSwitch.forEach((link) => {
-    const lang = link.dataset.lang;
-    if (lang === currentLang) {
-      link.classList.add('lang-switch__option--active');
-      link.setAttribute('aria-current', 'true');
-    }
-
-    link.addEventListener('click', (e) => {
-      e.preventDefault();
-      if (lang === currentLang) return;
-      const segments = window.location.pathname.split('/');
-      segments[1] = lang || 'es';
-      window.location.href = segments.join('/');
+  // Mark active on load and after ClientRouter transitions
+  const markActive = () => {
+    const currentLang = document.location.pathname.includes('/en/') ? 'en' : 'es';
+    document.querySelectorAll<HTMLAnchorElement>('.lang-switch__option').forEach((link) => {
+      const isActive = link.dataset.lang === currentLang;
+      link.classList.toggle('lang-switch__option--active', isActive);
+      if (isActive) link.setAttribute('aria-current', 'true');
+      else link.removeAttribute('aria-current');
     });
+  };
+  markActive();
+  document.addEventListener('astro:page-load', markActive);
+
+  // Click delegation (single listener on document, survives transitions)
+  document.addEventListener('click', (e) => {
+    const link = (e.target as HTMLElement).closest<HTMLAnchorElement>('.lang-switch__option');
+    if (!link) return;
+    e.preventDefault();
+    const currentLang = document.location.pathname.includes('/en/') ? 'en' : 'es';
+    const lang = link.dataset.lang;
+    if (lang === currentLang) return;
+    const segments = window.location.pathname.split('/');
+    segments[1] = lang || 'es';
+    window.location.href = segments.join('/');
   });
 </script>
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -305,16 +305,12 @@ const { active = 'home', language = 'es' } = Astro.props;
 </style>
 
 <script>
-  const bar = document.querySelector<HTMLElement>('.top-app-bar');
-  const burger = document.querySelector<HTMLButtonElement>('.top-app-bar__burger');
-  const drawer = document.querySelector<HTMLElement>('.mobile-drawer');
-  const backdrop = drawer?.querySelector('.mobile-drawer__backdrop');
-
-  const onScroll = () => bar?.setAttribute('data-scrolled', String(window.scrollY > 16));
-  window.addEventListener('scroll', onScroll, { passive: true });
-  onScroll();
+  // Event delegation on document/window so handlers survive ClientRouter transitions
+  // (the header/drawer DOM nodes are replaced between pages, but document/window persist).
 
   const setDrawer = (open: boolean) => {
+    const burger = document.querySelector<HTMLButtonElement>('.top-app-bar__burger');
+    const drawer = document.querySelector<HTMLElement>('.mobile-drawer');
     if (!burger || !drawer) return;
     burger.setAttribute('aria-expanded', String(open));
     drawer.setAttribute('data-open', String(open));
@@ -324,12 +320,44 @@ const { active = 'home', language = 'es' } = Astro.props;
       el.tabIndex = open ? 0 : -1;
     });
   };
-  setDrawer(false);
-  burger?.addEventListener('click', () => {
-    setDrawer(burger.getAttribute('aria-expanded') !== 'true');
+
+  const updateScrolled = () => {
+    const bar = document.querySelector<HTMLElement>('.top-app-bar');
+    bar?.setAttribute('data-scrolled', String(window.scrollY > 16));
+  };
+
+  // Click delegation: handles burger toggle, backdrop close, and closing drawer on nav link click
+  document.addEventListener('click', (e) => {
+    const target = e.target as HTMLElement;
+    if (target.closest('.top-app-bar__burger')) {
+      const burger = document.querySelector<HTMLButtonElement>('.top-app-bar__burger');
+      setDrawer(burger?.getAttribute('aria-expanded') !== 'true');
+      return;
+    }
+    if (target.closest('.mobile-drawer__backdrop')) {
+      setDrawer(false);
+      return;
+    }
+    if (target.closest('.mobile-drawer__link')) {
+      setDrawer(false);
+    }
   });
-  backdrop?.addEventListener('click', () => setDrawer(false));
+
+  // Escape closes drawer
   document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape') setDrawer(false);
   });
+
+  // Scroll listener on window (persists across transitions)
+  window.addEventListener('scroll', updateScrolled, { passive: true });
+
+  // Reset drawer state and re-check scroll after each ClientRouter page swap
+  document.addEventListener('astro:page-load', () => {
+    setDrawer(false);
+    updateScrolled();
+  });
+
+  // Initial call
+  updateScrolled();
+  setDrawer(false);
 </script>

--- a/src/components/SocialProof.astro
+++ b/src/components/SocialProof.astro
@@ -46,12 +46,12 @@ const logos = socialProof.logos;
     flex-wrap: wrap;
     justify-content: center;
     align-items: center;
-    gap: clamp(2rem, 5vw, 3.5rem);
+    gap: 1rem clamp(1.5rem, 4vw, 3rem);
   }
 
   .social-proof__logo {
     font-family: 'Manrope', sans-serif;
-    font-size: clamp(0.875rem, 1.5vw, 1rem);
+    font-size: clamp(0.8125rem, 1.5vw, 1rem);
     font-weight: 700;
     letter-spacing: 0.02em;
     color: var(--on-surface-variant);
@@ -63,20 +63,6 @@ const logos = socialProof.logos;
 
   .social-proof__logo:hover {
     opacity: 0.7;
-  }
-
-  @media (max-width: 640px) {
-    .social-proof__strip {
-      overflow-x: auto;
-      flex-wrap: nowrap;
-      justify-content: flex-start;
-      padding-inline: 0.5rem;
-      -webkit-overflow-scrolling: touch;
-      scrollbar-width: none;
-    }
-    .social-proof__strip::-webkit-scrollbar {
-      display: none;
-    }
   }
 
   @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Handlers attached directly to DOM broke after ClientRouter transitions. Move to document-level delegation (persists across transitions). Also wrap social proof logos on all sizes.