### PR TITLE
fix(layout): more bottom padding on mobile

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -75,7 +75,7 @@ const lang = Astro.url.pathname.startsWith('/en') ? 'en' : 'es';
   /* Reserve space so BottomNavBar does not cover the last block on mobile */
   @media (max-width: 767px) {
     body {
-      padding-bottom: calc(4.5rem + env(safe-area-inset-bottom, 0));
+      padding-bottom: calc(6.5rem + env(safe-area-inset-bottom, 0));
     }
   }
 </style>


### PR DESCRIPTION
4.5rem was not enough — BottomNavBar was covering the last block of content on mobile. Bump to 6.5rem + safe-area-inset-bottom.