### PR TITLE
feat(about): edad dinámica en cliente y actualizar entrada Geniova [MFS-TSK-0049]

### DIFF
--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -26,6 +26,36 @@ const slides = aboutData[language]?.slides || [];
     });
   }
 
+  /**
+   * Calcula la edad en años a partir de una fecha ISO (YYYY-MM-DD).
+   * @param {string} isoDate - Fecha de nacimiento en formato ISO.
+   * @returns {number} Edad actual en años completos.
+   */
+  function calculateAge(isoDate: string): number {
+    const birthDate = new Date(isoDate);
+    const today = new Date();
+    let age = today.getFullYear() - birthDate.getFullYear();
+    const monthDiff = today.getMonth() - birthDate.getMonth();
+
+    if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birthDate.getDate())) {
+      age--;
+    }
+
+    return age;
+  }
+
+  /**
+   * Recalcula en runtime la edad de cada placeholder .js-age para que el
+   * número se mantenga correcto sin necesidad de reconstruir el sitio.
+   */
+  function updateAges() {
+    document.querySelectorAll<HTMLElement>('.js-age').forEach((el) => {
+      const birthdate = el.dataset.birthdate;
+      if (!birthdate) return;
+      el.textContent = String(calculateAge(birthdate));
+    });
+  }
+
   document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.nav-button').forEach((button, index) => {
       button.addEventListener('click', () => {
@@ -36,6 +66,9 @@ const slides = aboutData[language]?.slides || [];
     // Inicializar el primer slide
     goToSlide(0);
   });
+
+  // Fires en la carga inicial y tras cada navegación con ClientRouter (View Transitions).
+  document.addEventListener('astro:page-load', updateAges);
 </script>
 
 <div class="pagecontent">

--- a/src/data/about.js
+++ b/src/data/about.js
@@ -52,7 +52,7 @@ El siguiente reto en una pequeña, por aquel entonces, empresa de reservas hotel
 Volví a Orange, al departamento de I+D, en el que estuve 4 años, para después pasar al equipo de desarrollo de la web de Orange.\n
 En 2015 me uní a Kairós DS, siendo el empleado 23 y donde comencé a dar el giro hacia el liderazgo de equipos y proyectos.\n
 Durante 2023-2024, ejercí como Director de Operaciones en Lean Mind.\n
-Desde enero de 2025 hasta abril de 2026, monté el equipo de IT de Geniova y digitalizamos todo el proceso de producción, e implementé un framework de desarrollo con IA.
+Desde enero de 2025 hasta abril de 2026, como Head of Engineering en Geniova, monté el equipo de IT y digitalizamos todo el proceso de producción, e implementé un framework de desarrollo con IA.
       `
       }
     ]
@@ -83,7 +83,7 @@ I then moved to the travel and hospitality sector at Mundicolor, part of the Mar
 I returned to Orange, where I spent 4 years in the R&D department, before joining the web development team at Orange.\n
 In 2015, I joined Kairós DS as the 23rd employee, where I began transitioning towards team and project leadership.\n
 During 2023-2024, I served as Director of Operations at Lean Mind.\n
-From January 2025 to April 2026, I built Geniova's IT team, we digitalized the entire production process, and I implemented an AI-assisted development framework.
+From January 2025 to April 2026, as Head of Engineering at Geniova, I built the IT team, we digitalized the entire production process, and I implemented an AI-assisted development framework.
       `
       }
     ]

--- a/src/data/about.js
+++ b/src/data/about.js
@@ -1,4 +1,9 @@
-const calculateAge = (birthDate) => {
+// Fecha de nacimiento en formato ISO: única fuente de verdad, reutilizada
+// por el fallback de build (edad) y por el cálculo en cliente (About.astro).
+export const BIRTH_DATE = '1971-05-08';
+
+const calculateAge = (isoDate) => {
+  const birthDate = new Date(isoDate);
   const today = new Date();
   let age = today.getFullYear() - birthDate.getFullYear();
   const monthDiff = today.getMonth() - birthDate.getMonth();
@@ -10,7 +15,8 @@ const calculateAge = (birthDate) => {
   return age;
 };
 
-const edad = calculateAge(new Date(1971, 4, 8));
+// Valor calculado en build como fallback (sin JS); el cliente lo recalcula en runtime.
+const edad = calculateAge(BIRTH_DATE);
 const ultimosaños = new Date().getFullYear() - 1997;
 
 export const aboutDesc = {
@@ -24,7 +30,7 @@ export const aboutData = {
     slides: [
       {
         subtitle: 'Personal',
-        description: `Tengo ${edad} años. Nacido en Mayo.\nExtrovertido y divertido.\nApasionado. Creativo. Resolutivo.\nQuisquilloso a veces. Testarudo.\nMe molestan los cambios imprevistos, pero me adapto rápido a ellos.\nSoy el mayor de 5 hermanos.\nEsposo de una persona maravillosa y padre de dos jovenes estupendos.\nActualmente trabajo como Head of Engineering en Geniova Technologies.`
+        description: `Tengo <span class="js-age" data-birthdate="${BIRTH_DATE}">${edad}</span> años. Nacido en Mayo.\nExtrovertido y divertido.\nApasionado. Creativo. Resolutivo.\nQuisquilloso a veces. Testarudo.\nMe molestan los cambios imprevistos, pero me adapto rápido a ellos.\nSoy el mayor de 5 hermanos.\nEsposo de una persona maravillosa y padre de dos jovenes estupendos.\nActualmente trabajo como Head of Engineering en Geniova Technologies.`
       },
       {
         subtitle: 'Profesional',
@@ -46,7 +52,7 @@ El siguiente reto en una pequeña, por aquel entonces, empresa de reservas hotel
 Volví a Orange, al departamento de I+D, en el que estuve 4 años, para después pasar al equipo de desarrollo de la web de Orange.\n
 En 2015 me uní a Kairós DS, siendo el empleado 23 y donde comencé a dar el giro hacia el liderazgo de equipos y proyectos.\n
 Durante 2023-2024, ejercí como Director de Operaciones en Lean Mind.\n
-Actualmente, desde enero de 2025, estoy enfocado en montar un equipo de ingenieria y dirigir toda la parte de desarrollo de software e IT en Geniova Technologies.
+Desde enero de 2025 hasta abril de 2026, monté el equipo de IT de Geniova y digitalizamos todo el proceso de producción, e implementé un framework de desarrollo con IA.
       `
       }
     ]
@@ -56,7 +62,7 @@ Actualmente, desde enero de 2025, estoy enfocado en montar un equipo de ingenier
     slides: [
       {
         subtitle: 'Personal',
-        description: `I'm ${edad} years old. Born in May.\nOutgoing and fun.\nPassionate. Creative. Problem-solver.\nPicky sometimes. Stubborn.\nUnexpected changes bother me, but I adapt quickly to them.\nI am the eldest of 5 siblings.\nHusband to a wonderful person and father of two amazing young people.\nCurrently, I am Head of Engineering at Geniova Technologies.\n`
+        description: `I'm <span class="js-age" data-birthdate="${BIRTH_DATE}">${edad}</span> years old. Born in May.\nOutgoing and fun.\nPassionate. Creative. Problem-solver.\nPicky sometimes. Stubborn.\nUnexpected changes bother me, but I adapt quickly to them.\nI am the eldest of 5 siblings.\nHusband to a wonderful person and father of two amazing young people.\nCurrently, I am Head of Engineering at Geniova Technologies.\n`
       },
       {
         subtitle: 'Professional',
@@ -77,7 +83,7 @@ I then moved to the travel and hospitality sector at Mundicolor, part of the Mar
 I returned to Orange, where I spent 4 years in the R&D department, before joining the web development team at Orange.\n
 In 2015, I joined Kairós DS as the 23rd employee, where I began transitioning towards team and project leadership.\n
 During 2023-2024, I served as Director of Operations at Lean Mind.\n
-Currently, since January 2025, I am focused on building an engineering team and leading all software development and IT at Geniova Technologies.
+From January 2025 to April 2026, I built Geniova's IT team, we digitalized the entire production process, and I implemented an AI-assisted development framework.
       `
       }
     ]


### PR DESCRIPTION
## Qué

- **Edad dinámica**: la edad se calcula en el navegador (`astro:page-load`) a partir de `1971-05-08`, en vez de quedar congelada por el build de Astro SSG. El valor calculado en build se mantiene como fallback para clientes sin JS. Única fuente de la fecha: constante `BIRTH_DATE` en `about.js`.
- **Experiencia**: se reemplaza la última entrada por la etapa en Geniova (enero 2025 – abril 2026), en es y en.

## Por qué

El número de edad lo fijaba el build (último deploy mostraba 54). Ahora se actualiza solo sin necesidad de reconstruir ni desplegar.

## Notas

- Las referencias 'Actualmente / Head of Engineering en Geniova' (cabecera, slide Personal, trayectoria) se mantienen sin cambios a petición del autor; queda como posible seguimiento si procede actualizarlas a pasado.
- Sin configuración de SonarQube en el proyecto; cambio verificado vía `npm run build` (HTML renderiza edad=55 y textos correctos).

Card: MFS-TSK-0049